### PR TITLE
fix: add missing space before alt attribute

### DIFF
--- a/photo-gallery.html
+++ b/photo-gallery.html
@@ -24,7 +24,7 @@
 
 		<div>
 			<a href="photo-gallery bw.html"> <img src="img/photo-gallery/1 (5).jpg" class="lead-bw-photo" alt=""></a>
-			<a href="photo-gallery clr.html"> <img src="img/photo-gallery/2 (5).jpg" class="lead-clr-photo"alt=""></a>
+			<a href="photo-gallery clr.html"> <img src="img/photo-gallery/2 (5).jpg" class="lead-clr-photo" alt=""></a>
 		</div>
  </body>
 


### PR DESCRIPTION
## Summary
- fix missing space before `alt` in photo gallery image link

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6895f3030d98832c8a57594635565d05