### PR TITLE
[codex] polish frontend review fixes

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -6,7 +6,7 @@
   --color-bg: #fff;
   --color-link: #007aff;
   --max-width: 960px;
-  --spacing: 1.5rem;
+  --site-spacing: 1.5rem;
 }
 
 *,
@@ -17,7 +17,7 @@
 
 body {
   margin: 0;
-  padding: var(--spacing);
+  padding: var(--site-spacing);
   font-family: var(--font-sans);
   background: var(--color-bg);
   color: var(--color-text);
@@ -25,7 +25,7 @@ body {
 }
 
 body[data-page] {
-  padding-top: calc(var(--spacing) * 3.75);
+  padding-top: calc(var(--site-spacing) * 3.75);
 }
 
 a {
@@ -42,7 +42,7 @@ h1,
 .h1-second {
   font-size: 2rem;
   font-weight: 400;
-  margin-bottom: var(--spacing);
+  margin-bottom: var(--site-spacing);
 }
 
 .h1-second {
@@ -52,7 +52,7 @@ h1,
 h2 {
   font-size: 1.25rem;
   font-weight: 400;
-  margin: var(--spacing) 0;
+  margin: var(--site-spacing) 0;
 }
 
 .heading .links {
@@ -66,13 +66,13 @@ h2 {
 .story-cover,
 .story-mag {
   font-family: var(--font-mono);
-  margin-bottom: var(--spacing);
+  margin-bottom: var(--site-spacing);
 }
 
 .photos {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-  gap: var(--spacing);
+  gap: var(--site-spacing);
 }
 
 .photos img,
@@ -88,8 +88,8 @@ h2 {
 
 .back-nav-link {
   position: fixed;
-  top: var(--spacing);
-  left: var(--spacing);
+  top: var(--site-spacing);
+  left: var(--site-spacing);
 }
 
 .back-nav {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
+    "test": "node --test tests/*.test.mjs",
     "preview": "vite preview"
   },
   "devDependencies": {

--- a/src/app.css
+++ b/src/app.css
@@ -101,9 +101,15 @@
 }
 
 .react-gallery-grid {
-  display: grid;
-  gap: 1rem;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  column-count: 1;
+  column-gap: 1rem;
+}
+
+.react-gallery-grid > * {
+  display: inline-block;
+  width: 100%;
+  margin: 0 0 1rem;
+  break-inside: avoid;
 }
 
 .react-gallery-image {
@@ -111,4 +117,16 @@
   width: 100%;
   height: auto;
   object-fit: cover;
+}
+
+@media (min-width: 640px) {
+  .react-gallery-grid {
+    column-count: 2;
+  }
+}
+
+@media (min-width: 960px) {
+  .react-gallery-grid {
+    column-count: 3;
+  }
 }

--- a/src/react-site-data.js
+++ b/src/react-site-data.js
@@ -4,6 +4,36 @@ import magazineHtml from "../magazine.html?raw";
 import magazineCoverHtml from "../magazine-cover.html?raw";
 import photoGalleryHtml from "../photo-gallery.html?raw";
 
+import magazineSpread1 from "../img/magazine/2-1.jpg";
+import magazineSpread2 from "../img/magazine/2-2.jpg";
+import magazineSpread3 from "../img/magazine/2-3.jpg";
+import magazineSpread4 from "../img/magazine/2-4.jpg";
+import magazineSpread5 from "../img/magazine/2-5.jpg";
+import magazineSpread6 from "../img/magazine/2-6.jpg";
+import magazineSpread7 from "../img/magazine/2-7.jpg";
+import magazineSpread8 from "../img/magazine/2-8.jpg";
+import magazineSpread9 from "../img/magazine/2-9.jpg";
+import magazineCover from "../img/magazine/2-10.jpg";
+import bwPhoto1 from "../img/photo-gallery/1-5.jpg";
+import bwPhoto2 from "../img/photo-gallery/1-1.jpg";
+import bwPhoto3 from "../img/photo-gallery/1-3.jpg";
+import bwPhoto4 from "../img/photo-gallery/1-4.jpg";
+import bwPhoto5 from "../img/photo-gallery/1-6.jpg";
+import bwPhoto6 from "../img/photo-gallery/1-8.jpg";
+import bwPhoto7 from "../img/photo-gallery/1-7.jpg";
+import bwPhoto8 from "../img/photo-gallery/1-10.jpg";
+import bwPhoto9 from "../img/photo-gallery/1-11.jpg";
+import bwPhoto10 from "../img/photo-gallery/1-12.jpg";
+import colorPhoto1 from "../img/photo-gallery/2-5.jpg";
+import colorPhoto2 from "../img/photo-gallery/2-2.jpg";
+import colorPhoto3 from "../img/photo-gallery/2-1.jpg";
+import colorPhoto4 from "../img/photo-gallery/2-4.jpg";
+import colorPhoto5 from "../img/photo-gallery/2-6.jpg";
+import colorPhoto6 from "../img/photo-gallery/2-8.jpg";
+import colorPhoto7 from "../img/photo-gallery/2-7.jpg";
+import colorPhoto8 from "../img/photo-gallery/2-3.jpg";
+import colorPhoto9 from "../img/photo-gallery/2-10.jpg";
+
 function extractInnerHtml(html, pattern, fallback = "") {
   const match = html.match(pattern);
   return match ? match[1].trim() : fallback;
@@ -50,13 +80,13 @@ export const designProjects = [
   {
     title: "Student magazine",
     href: reactPageMap.magazine,
-    image: "img/magazine/2-2.jpg",
+    image: magazineSpread2,
     alt: "Magazine spread preview"
   },
   {
     title: "Magazine cover",
     href: reactPageMap["magazine-cover"],
-    image: "img/magazine/2-10.jpg",
+    image: magazineCover,
     alt: "Magazine cover preview"
   }
 ];
@@ -65,53 +95,55 @@ export const photoBranches = [
   {
     title: "Black and white",
     href: reactPageMap["photo-gallery-bw"],
-    image: "img/photo-gallery/1-5.jpg",
+    image: bwPhoto1,
     alt: "Black and white gallery preview"
   },
   {
     title: "Color",
     href: reactPageMap["photo-gallery-clr"],
-    image: "img/photo-gallery/2-5.jpg",
+    image: colorPhoto1,
     alt: "Color gallery preview"
   }
 ];
 
 export const bwPhotos = [
-  "img/photo-gallery/1-5.jpg",
-  "img/photo-gallery/1-1.jpg",
-  "img/photo-gallery/1-3.jpg",
-  "img/photo-gallery/1-4.jpg",
-  "img/photo-gallery/1-6.jpg",
-  "img/photo-gallery/1-8.jpg",
-  "img/photo-gallery/1-7.jpg",
-  "img/photo-gallery/1-10.jpg",
-  "img/photo-gallery/1-11.jpg",
-  "img/photo-gallery/1-12.jpg"
+  bwPhoto1,
+  bwPhoto2,
+  bwPhoto3,
+  bwPhoto4,
+  bwPhoto5,
+  bwPhoto6,
+  bwPhoto7,
+  bwPhoto8,
+  bwPhoto9,
+  bwPhoto10
 ];
 
 export const colorPhotos = [
-  "img/photo-gallery/2-5.jpg",
-  "img/photo-gallery/2-2.jpg",
-  "img/photo-gallery/2-1.jpg",
-  "img/photo-gallery/2-4.jpg",
-  "img/photo-gallery/2-6.jpg",
-  "img/photo-gallery/2-8.jpg",
-  "img/photo-gallery/2-7.jpg",
-  "img/photo-gallery/2-3.jpg",
-  "img/photo-gallery/2-10.jpg"
+  colorPhoto1,
+  colorPhoto2,
+  colorPhoto3,
+  colorPhoto4,
+  colorPhoto5,
+  colorPhoto6,
+  colorPhoto7,
+  colorPhoto8,
+  colorPhoto9
 ];
 
 export const magazinePhotos = [
-  "img/magazine/2-1.jpg",
-  "img/magazine/2-2.jpg",
-  "img/magazine/2-3.jpg",
-  "img/magazine/2-4.jpg",
-  "img/magazine/2-5.jpg",
-  "img/magazine/2-6.jpg",
-  "img/magazine/2-7.jpg",
-  "img/magazine/2-8.jpg",
-  "img/magazine/2-9.jpg"
+  magazineSpread1,
+  magazineSpread2,
+  magazineSpread3,
+  magazineSpread4,
+  magazineSpread5,
+  magazineSpread6,
+  magazineSpread7,
+  magazineSpread8,
+  magazineSpread9
 ];
+
+export const magazineCoverImage = magazineCover;
 
 export const copyBlocks = {
   cv: extractInnerHtml(cvHtml, /<article>([\s\S]*?)<\/article>/i),

--- a/src/react-site.jsx
+++ b/src/react-site.jsx
@@ -29,6 +29,7 @@ import {
   reactPageMap,
   socialLinks,
   staticPageMap,
+  magazineCoverImage,
   magazinePhotos
 } from "@/react-site-data";
 
@@ -173,7 +174,7 @@ function HomePage() {
               </div>
               <div className="sm:shrink-0">
                 <Button variant="ghost" className="justify-between px-0 sm:px-3" asChild>
-                  <a href={link.href}>
+                  <a href={link.href} aria-label={`Open ${link.title}`}>
                     Open page
                     <ArrowRight className="size-4" />
                   </a>
@@ -279,7 +280,7 @@ function DesignPage() {
           </CardHeader>
           <CardFooter>
             <Button variant="outline" className="w-full justify-between" asChild>
-              <a href={project.href}>
+              <a href={project.href} aria-label={`Open ${project.title}`}>
                 Open project
                 <ArrowRight className="size-4" />
               </a>
@@ -327,7 +328,7 @@ function MagazineCoverPage() {
       </Card>
       <Card className="overflow-hidden border-border/70 bg-background/92 p-0 shadow-none">
         <img
-          src="img/magazine/2-10.jpg"
+          src={magazineCoverImage}
           alt="Magazine cover"
           className="react-gallery-image"
         />
@@ -387,7 +388,7 @@ function PhotoHubPage() {
             </CardHeader>
             <CardFooter>
               <Button variant="outline" className="w-full justify-between" asChild>
-                <a href={branch.href}>
+                <a href={branch.href} aria-label={`Open ${branch.title} gallery`}>
                   Open gallery
                   <ArrowRight className="size-4" />
                 </a>

--- a/tests/frontend-regression.test.mjs
+++ b/tests/frontend-regression.test.mjs
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const readProjectFile = (path) => readFileSync(resolve(root, path), "utf8");
+
+test("legacy CSS does not override Tailwind spacing scale", () => {
+  const css = readProjectFile("css/styles.css");
+
+  assert.equal(
+    /--spacing\s*:/.test(css),
+    false,
+    "Use a site-scoped spacing variable so Tailwind utilities keep their scale."
+  );
+  assert.match(css, /--site-spacing\s*:/);
+});
+
+test("React image data does not use raw public paths", () => {
+  const data = readProjectFile("src/react-site-data.js");
+
+  assert.equal(
+    /["']img\/(?:magazine|photo-gallery)\//.test(data),
+    false,
+    "Image data should use Vite-resolved asset URLs, not raw img/... strings."
+  );
+});
+
+test("React gallery layout prevents stretched blank card interiors", () => {
+  const css = readProjectFile("src/app.css");
+
+  assert.match(css, /\.react-gallery-grid\s*\{/);
+  assert.match(
+    css,
+    /break-inside:\s*avoid|align-items:\s*start|aspect-ratio:/,
+    "Gallery cards need masonry, top-alignment, or fixed aspect ratio treatment."
+  );
+});
+
+test("Repeated React CTA links have unique accessible names", () => {
+  const jsx = readProjectFile("src/react-site.jsx");
+
+  assert.match(jsx, /aria-label=\{`Open \$\{link\.title\}`\}/);
+  assert.match(jsx, /aria-label=\{`Open \$\{project\.title\}`\}/);
+  assert.match(jsx, /aria-label=\{`Open \$\{branch\.title\} gallery`\}/);
+});


### PR DESCRIPTION
## Summary

- Renamed the legacy CSS spacing token so Tailwind 4 spacing utilities keep their intended scale.
- Switched React gallery/project image data to Vite-resolved imports so production pages load fingerprinted assets.
- Reworked the React gallery grid into a masonry-style layout to avoid stretched blank card interiors.
- Added unique accessible names for repeated React CTA links.
- Added Node regression tests covering the reviewed frontend issues.

## Root Cause

The React app imported the legacy static stylesheet, whose `--spacing` custom property collided with Tailwind 4's spacing token and inflated utility-driven layout. React image paths were also stored as raw `img/...` strings, so Vite did not rewrite them for production assets.

## Validation

- `npm.cmd test`
- `npm.cmd run build`
- `git diff --cached --check`
- Production preview check: React design image src resolves to `/evgeny_chekov/assets/...jpg`; direct asset request returned `image/jpeg` with JPEG bytes.